### PR TITLE
feat: guided motif palette UI 추가

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -64,11 +64,29 @@
 }
 
 .canvas-frame {
+  position: relative;
   padding: 1rem;
   border-radius: 18px;
   background:
     linear-gradient(135deg, rgba(255, 248, 239, 0.95), rgba(247, 238, 228, 0.85));
   border: 1px dashed rgba(31, 28, 24, 0.16);
+}
+
+.canvas-guide-overlay {
+  position: absolute;
+  inset: 1rem;
+  width: calc(100% - 2rem);
+  height: calc(100% - 2rem);
+  pointer-events: none;
+}
+
+.canvas-guide-overlay path {
+  fill: none;
+  stroke: rgba(194, 111, 38, 0.42);
+  stroke-width: 14;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 16 20;
 }
 
 .canvas-surface {
@@ -122,6 +140,30 @@
 .status-card ul {
   padding-left: 1.2rem;
   color: var(--muted-ink);
+}
+
+.guide-palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
+.guide-chip {
+  border: 1px solid rgba(31, 28, 24, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.88);
+  color: #1f1c18;
+  padding: 0.65rem 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.guide-chip--selected {
+  background: #1f1c18;
+  color: #fff7ef;
+  border-color: #1f1c18;
+  box-shadow: 0 12px 24px rgba(31, 28, 24, 0.16);
 }
 
 .session-controls {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,19 +1,28 @@
-import { useReducer } from "react";
+import { useMemo, useReducer, useState } from "react";
 import { useAudioSession } from "../features/audio/hooks/useAudioSession";
 import { deriveAudioLayers } from "../features/audio/model/audioLayers";
 import { CanvasSurface } from "../features/canvas/CanvasSurface";
+import { guideTemplates } from "../features/guides/model/guideTemplates";
 import { strokeSessionReducer } from "../features/canvas/model/strokeSession";
 import { classifyStrokes } from "../features/scene/model/classifyScene";
-import type { SceneElement, Stroke } from "../shared/types/domain";
+import type { GuideTemplate, SceneElement, Stroke } from "../shared/types/domain";
 import "./App.css";
 
 export function App() {
   const [strokes, dispatch] = useReducer(strokeSessionReducer, [] as Stroke[]);
+  const [selectedGuideId, setSelectedGuideId] = useState<string>(
+    guideTemplates[0]?.id ?? "",
+  );
   const sceneElements = classifyStrokes(strokes);
   const { pause, replay, reset: resetAudio, sessionState } =
     useAudioSession(sceneElements);
   const audioLayers = deriveAudioLayers(sceneElements, sessionState);
   const visibleMotifs = sceneElements.slice(-3);
+  const selectedGuide = useMemo(
+    () =>
+      guideTemplates.find((guide) => guide.id === selectedGuideId) ?? null,
+    [selectedGuideId],
+  );
 
   const resetSession = async () => {
     dispatch({ type: "reset" });
@@ -37,14 +46,45 @@ export function App() {
           onStrokeComplete={(stroke) => {
             dispatch({ type: "add", stroke });
           }}
+          selectedGuide={selectedGuide}
           strokes={strokes}
         />
 
         <aside className="status-panel" aria-label="Session status">
           <div className="status-card">
+            <p className="eyebrow">Guided input</p>
+            <h2>Choose a motif guide</h2>
+            <div className="guide-palette" role="group" aria-label="Motif guides">
+              {guideTemplates.map((guide: GuideTemplate) => {
+                const isSelected = guide.id === selectedGuide?.id;
+
+                return (
+                  <button
+                    aria-pressed={isSelected}
+                    className={isSelected ? "guide-chip guide-chip--selected" : "guide-chip"}
+                    key={guide.id}
+                    onClick={() => {
+                      setSelectedGuideId(guide.id);
+                    }}
+                    type="button"
+                  >
+                    {guide.label} guide
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="status-card">
             <p className="eyebrow">Drawing status</p>
             <h2>Canvas snapshot</h2>
             <dl>
+              <div>
+                <dt>Selected guide</dt>
+                <dd data-testid="selected-guide">
+                  {selectedGuide ? selectedGuide.label : "None"}
+                </dd>
+              </div>
               <div>
                 <dt>Strokes</dt>
                 <dd data-testid="stroke-count">{strokes.length}</dd>

--- a/src/features/canvas/CanvasSurface.tsx
+++ b/src/features/canvas/CanvasSurface.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
-import type { Stroke } from "../../shared/types/domain";
+import type { GuideTemplate, Stroke } from "../../shared/types/domain";
 
 type CanvasSurfaceProps = {
   strokes: Stroke[];
   onStrokeComplete: (stroke: Stroke) => void;
+  selectedGuide: GuideTemplate | null;
   width?: number;
   height?: number;
 };
@@ -50,6 +51,7 @@ function drawStroke(
 export function CanvasSurface({
   strokes,
   onStrokeComplete,
+  selectedGuide,
   width = 960,
   height = 540,
 }: CanvasSurfaceProps) {
@@ -137,6 +139,21 @@ export function CanvasSurface({
       </div>
 
       <div className="canvas-frame">
+        {selectedGuide ? (
+          <svg
+            aria-label={`${selectedGuide.label} guide overlay`}
+            className="canvas-guide-overlay"
+            viewBox={`0 0 ${width} ${height}`}
+          >
+            <path
+              d={selectedGuide.previewPath
+                .map((point, index) =>
+                  `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`,
+                )
+                .join(" ")}
+            />
+          </svg>
+        ) : null}
         <canvas
           aria-label="BGM Canvas drawing surface"
           className="canvas-surface"

--- a/src/features/guides/model/guideTemplates.ts
+++ b/src/features/guides/model/guideTemplates.ts
@@ -1,0 +1,61 @@
+import type { GuideTemplate } from "../../../shared/types/domain";
+
+export const guideTemplates: GuideTemplate[] = [
+  {
+    id: "guide-campfire",
+    motif: "campfire",
+    label: "Campfire",
+    previewPath: [
+      { x: 390, y: 420 },
+      { x: 460, y: 250 },
+      { x: 530, y: 420 },
+      { x: 480, y: 210 },
+      { x: 430, y: 420 },
+    ],
+  },
+  {
+    id: "guide-rain",
+    motif: "rain",
+    label: "Rain",
+    previewPath: [
+      { x: 300, y: 170 },
+      { x: 360, y: 260 },
+      { x: 330, y: 240 },
+      { x: 390, y: 330 },
+      { x: 360, y: 310 },
+      { x: 420, y: 400 },
+    ],
+  },
+  {
+    id: "guide-tree",
+    motif: "tree",
+    label: "Tree",
+    previewPath: [
+      { x: 470, y: 430 },
+      { x: 470, y: 330 },
+      { x: 410, y: 250 },
+      { x: 470, y: 170 },
+      { x: 530, y: 250 },
+      { x: 470, y: 330 },
+      { x: 470, y: 430 },
+    ],
+  },
+  {
+    id: "guide-star",
+    motif: "star",
+    label: "Star",
+    previewPath: [
+      { x: 480, y: 150 },
+      { x: 510, y: 230 },
+      { x: 600, y: 230 },
+      { x: 530, y: 285 },
+      { x: 555, y: 370 },
+      { x: 480, y: 320 },
+      { x: 405, y: 370 },
+      { x: 430, y: 285 },
+      { x: 360, y: 230 },
+      { x: 450, y: 230 },
+      { x: 480, y: 150 },
+    ],
+  },
+];

--- a/src/shared/types/domain.ts
+++ b/src/shared/types/domain.ts
@@ -16,7 +16,17 @@ export type Motif =
   | "tree"
   | "star"
   | "sea"
+  | "window"
+  | "lamp"
+  | "desk"
   | "unknown";
+
+export type GuideTemplate = {
+  id: string;
+  motif: Motif;
+  label: string;
+  previewPath: Point[];
+};
 
 export type SceneElement = {
   id: string;

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -14,6 +14,20 @@ test("loads the bootstrap canvas shell", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "Canvas snapshot" }),
   ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Choose a motif guide" }),
+  ).toBeVisible();
+});
+
+test("switches the selected guide and shows the matching overlay", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Rain guide" }).click();
+
+  await expect(page.getByTestId("selected-guide")).toHaveText("Rain");
+  await expect(page.getByLabel("Rain guide overlay")).toBeVisible();
 });
 
 test("stores one stroke after drawing on the canvas", async ({ page }) => {

--- a/tests/unit/app-smoke.test.tsx
+++ b/tests/unit/app-smoke.test.tsx
@@ -16,7 +16,24 @@ describe("App bootstrap", () => {
     expect(
       screen.getByLabelText(/bgm canvas drawing surface/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /choose a motif guide/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /campfire guide/i }),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("audio-state")).toHaveTextContent("idle");
+  });
+
+  it("shows the selected guide in the status panel and canvas overlay", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /rain guide/i }));
+
+    expect(screen.getByTestId("selected-guide")).toHaveTextContent("Rain");
+    expect(
+      screen.getByLabelText(/rain guide overlay/i),
+    ).toBeInTheDocument();
   });
 
   it("stores a completed stroke after pointer drawing", async () => {


### PR DESCRIPTION
## 요약
- 사용 가능한 motif guide를 palette UI로 노출합니다.
- 선택된 guide를 캔버스 overlay와 상태 패널에 표시합니다.
- guided input MVP의 첫 UI slice를 추가합니다.

## 변경 사항
- guide template 상수 추가
- guide palette 및 선택 상태 추가
- canvas overlay 렌더링 추가
- unit/e2e smoke 테스트 확장

## 검증
- `npm run test`
- `npm run test:e2e`

Closes #9