### PR TITLE
feat: 가이드 기반 scene 매핑 추가

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,15 +5,31 @@ import { CanvasSurface } from "../features/canvas/CanvasSurface";
 import { guideTemplates } from "../features/guides/model/guideTemplates";
 import { strokeSessionReducer } from "../features/canvas/model/strokeSession";
 import { classifyStrokes } from "../features/scene/model/classifyScene";
+import { toGuidedSceneElement } from "../features/scene/model/guidedScene";
 import type { GuideTemplate, SceneElement, Stroke } from "../shared/types/domain";
 import "./App.css";
 
 export function App() {
   const [strokes, dispatch] = useReducer(strokeSessionReducer, [] as Stroke[]);
+  const [guidedSelections, setGuidedSelections] = useState<
+    Record<string, GuideTemplate>
+  >({});
   const [selectedGuideId, setSelectedGuideId] = useState<string>(
     guideTemplates[0]?.id ?? "",
   );
-  const sceneElements = classifyStrokes(strokes);
+  const sceneElements = useMemo(
+    () =>
+      strokes.map((stroke) => {
+        const guidedSelection = guidedSelections[stroke.id];
+
+        if (guidedSelection) {
+          return toGuidedSceneElement(stroke, guidedSelection);
+        }
+
+        return classifyStrokes([stroke])[0];
+      }),
+    [guidedSelections, strokes],
+  );
   const { pause, replay, reset: resetAudio, sessionState } =
     useAudioSession(sceneElements);
   const audioLayers = deriveAudioLayers(sceneElements, sessionState);
@@ -26,6 +42,7 @@ export function App() {
 
   const resetSession = async () => {
     dispatch({ type: "reset" });
+    setGuidedSelections({});
     await resetAudio();
   };
 
@@ -45,6 +62,12 @@ export function App() {
         <CanvasSurface
           onStrokeComplete={(stroke) => {
             dispatch({ type: "add", stroke });
+            if (selectedGuide) {
+              setGuidedSelections((currentSelections) => ({
+                ...currentSelections,
+                [stroke.id]: selectedGuide,
+              }));
+            }
           }}
           selectedGuide={selectedGuide}
           strokes={strokes}
@@ -145,6 +168,20 @@ export function App() {
               <button
                 disabled={strokes.length === 0}
                 onClick={() => {
+                  setGuidedSelections((currentSelections) => {
+                    if (strokes.length === 0) {
+                      return currentSelections;
+                    }
+
+                    const nextSelections = { ...currentSelections };
+                    const latestStroke = strokes.at(-1);
+
+                    if (latestStroke) {
+                      delete nextSelections[latestStroke.id];
+                    }
+
+                    return nextSelections;
+                  });
                   dispatch({ type: "undo" });
                 }}
                 type="button"

--- a/src/features/scene/model/guidedScene.ts
+++ b/src/features/scene/model/guidedScene.ts
@@ -1,0 +1,17 @@
+import type {
+  GuideTemplate,
+  SceneElement,
+  Stroke,
+} from "../../../shared/types/domain";
+
+export function toGuidedSceneElement(
+  stroke: Stroke,
+  guide: GuideTemplate,
+): SceneElement {
+  return {
+    id: `scene-${stroke.id}`,
+    strokeIds: [stroke.id],
+    motif: guide.motif,
+    confidence: 0.9,
+  };
+}

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -30,6 +30,20 @@ test("switches the selected guide and shows the matching overlay", async ({
   await expect(page.getByLabel("Rain guide overlay")).toBeVisible();
 });
 
+test("maps a guided drawing to the selected motif badge", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Rain guide" }).click();
+
+  const canvas = page.getByLabel("BGM Canvas drawing surface");
+  await canvas.hover({ position: { x: 120, y: 200 } });
+  await page.mouse.down();
+  await page.mouse.move(280, 220, { steps: 6 });
+  await page.mouse.up();
+
+  await expect(page.getByTestId("scene-badge").first()).toContainText("rain");
+});
+
 test("stores one stroke after drawing on the canvas", async ({ page }) => {
   await page.goto("/");
 
@@ -43,7 +57,7 @@ test("stores one stroke after drawing on the canvas", async ({ page }) => {
   await expect(page.getByTestId("scene-count")).toHaveText("1");
   await expect(page.getByTestId("audio-layer-count")).toHaveText("1");
   await expect(page.getByTestId("audio-state")).toHaveText("playing");
-  await expect(page.getByTestId("scene-badge").first()).toContainText("tree");
+  await expect(page.getByTestId("scene-badge").first()).toContainText("campfire");
 });
 
 test("undo and reset control the current drawing session", async ({ page }) => {

--- a/tests/unit/app-smoke.test.tsx
+++ b/tests/unit/app-smoke.test.tsx
@@ -83,6 +83,54 @@ describe("App bootstrap", () => {
     expect(screen.getByText(/single black line active/i)).toBeInTheDocument();
   });
 
+  it("uses the selected guide motif after drawing", async () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /rain guide/i }));
+
+    const canvas = screen.getByLabelText(
+      /bgm canvas drawing surface/i,
+    ) as HTMLCanvasElement;
+
+    canvas.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        width: 960,
+        height: 540,
+        right: 960,
+        bottom: 540,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    fireEvent.pointerDown(canvas, {
+      clientX: 20,
+      clientY: 160,
+      pointerId: 1,
+      buttons: 1,
+    });
+    fireEvent.pointerMove(canvas, {
+      clientX: 220,
+      clientY: 190,
+      pointerId: 1,
+      buttons: 1,
+    });
+    fireEvent.pointerUp(canvas, {
+      clientX: 220,
+      clientY: 190,
+      pointerId: 1,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("audio-layer-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("audio-state")).toHaveTextContent("playing");
+      expect(screen.getByTestId("scene-badge")).toHaveTextContent("rain");
+    });
+  });
+
   it("undoes the most recent stroke and resets the session", async () => {
     render(<App />);
 

--- a/tests/unit/scene/guidedScene.test.ts
+++ b/tests/unit/scene/guidedScene.test.ts
@@ -1,0 +1,31 @@
+import { guideTemplates } from "../../../src/features/guides/model/guideTemplates";
+import { toGuidedSceneElement } from "../../../src/features/scene/model/guidedScene";
+import type { Stroke } from "../../../src/shared/types/domain";
+
+function createStroke(points: Stroke["points"]): Stroke {
+  return {
+    id: "stroke-guided",
+    points,
+    createdAt: 1,
+  };
+}
+
+describe("guided scene mapping", () => {
+  it("maps a completed stroke to the selected guide motif", () => {
+    const stroke = createStroke([
+      { x: 10, y: 10 },
+      { x: 220, y: 20 },
+      { x: 440, y: 30 },
+    ]);
+
+    const rainGuide = guideTemplates.find((guide) => guide.motif === "rain");
+
+    expect(rainGuide).toBeDefined();
+    expect(toGuidedSceneElement(stroke, rainGuide!)).toMatchObject({
+      id: "scene-stroke-guided",
+      strokeIds: ["stroke-guided"],
+      motif: "rain",
+      confidence: 0.9,
+    });
+  });
+});


### PR DESCRIPTION
## 요약
- 선택된 guide를 completed stroke의 scene motif로 결정적으로 매핑합니다.
- guided stroke는 기존 heuristic 대신 selected guide 결과를 사용합니다.
- scene badge와 audio layer가 guide 선택을 즉시 반영하도록 연결합니다.

## 변경 사항
- guided scene mapper 추가
- app에 stroke별 guide selection 상태 연결
- undo/reset 시 guided selection state 정리
- unit/app/e2e 테스트 확장

## 검증
- `npm run test`
- `npm run test:e2e`

Closes #10