### PR TITLE
feat: guide match 성공 실패 규칙 추가

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,33 +2,46 @@ import { useMemo, useReducer, useState } from "react";
 import { useAudioSession } from "../features/audio/hooks/useAudioSession";
 import { deriveAudioLayers } from "../features/audio/model/audioLayers";
 import { CanvasSurface } from "../features/canvas/CanvasSurface";
+import { evaluateGuideMatch } from "../features/guides/model/guideMatch";
 import { guideTemplates } from "../features/guides/model/guideTemplates";
 import { strokeSessionReducer } from "../features/canvas/model/strokeSession";
 import { classifyStrokes } from "../features/scene/model/classifyScene";
 import { toGuidedSceneElement } from "../features/scene/model/guidedScene";
-import type { GuideTemplate, SceneElement, Stroke } from "../shared/types/domain";
+import type {
+  GuideTemplate,
+  GuidedInputState,
+  SceneElement,
+  Stroke,
+} from "../shared/types/domain";
 import "./App.css";
+
+type GuidedAttempt = {
+  guide: GuideTemplate;
+  match: GuidedInputState;
+};
 
 export function App() {
   const [strokes, dispatch] = useReducer(strokeSessionReducer, [] as Stroke[]);
-  const [guidedSelections, setGuidedSelections] = useState<
-    Record<string, GuideTemplate>
+  const [guidedAttempts, setGuidedAttempts] = useState<
+    Record<string, GuidedAttempt>
   >({});
-  const [selectedGuideId, setSelectedGuideId] = useState<string>(
-    guideTemplates[0]?.id ?? "",
-  );
+  const [selectedGuideId, setSelectedGuideId] = useState<string>("");
   const sceneElements = useMemo(
     () =>
-      strokes.map((stroke) => {
-        const guidedSelection = guidedSelections[stroke.id];
+      strokes.flatMap((stroke) => {
+        const guidedAttempt = guidedAttempts[stroke.id];
 
-        if (guidedSelection) {
-          return toGuidedSceneElement(stroke, guidedSelection);
+        if (guidedAttempt) {
+          if (guidedAttempt.match.status === "matched") {
+            return [toGuidedSceneElement(stroke, guidedAttempt.guide)];
+          }
+
+          return [];
         }
 
-        return classifyStrokes([stroke])[0];
+        return [classifyStrokes([stroke])[0]];
       }),
-    [guidedSelections, strokes],
+    [guidedAttempts, strokes],
   );
   const { pause, replay, reset: resetAudio, sessionState } =
     useAudioSession(sceneElements);
@@ -39,10 +52,25 @@ export function App() {
       guideTemplates.find((guide) => guide.id === selectedGuideId) ?? null,
     [selectedGuideId],
   );
+  const latestGuidedInput = useMemo(() => {
+    for (let index = strokes.length - 1; index >= 0; index -= 1) {
+      const guidedAttempt = guidedAttempts[strokes[index].id];
+
+      if (guidedAttempt) {
+        return guidedAttempt.match;
+      }
+    }
+
+    return {
+      selectedGuideId: selectedGuide?.id ?? null,
+      status: "idle",
+      progress: 0,
+    } satisfies GuidedInputState;
+  }, [guidedAttempts, selectedGuide?.id, strokes]);
 
   const resetSession = async () => {
     dispatch({ type: "reset" });
-    setGuidedSelections({});
+    setGuidedAttempts({});
     await resetAudio();
   };
 
@@ -63,9 +91,12 @@ export function App() {
           onStrokeComplete={(stroke) => {
             dispatch({ type: "add", stroke });
             if (selectedGuide) {
-              setGuidedSelections((currentSelections) => ({
-                ...currentSelections,
-                [stroke.id]: selectedGuide,
+              setGuidedAttempts((currentAttempts) => ({
+                ...currentAttempts,
+                [stroke.id]: {
+                  guide: selectedGuide,
+                  match: evaluateGuideMatch(stroke, selectedGuide),
+                },
               }));
             }
           }}
@@ -128,6 +159,16 @@ export function App() {
                 <dt>Audio state</dt>
                 <dd data-testid="audio-state">{sessionState}</dd>
               </div>
+              <div>
+                <dt>Guide match</dt>
+                <dd data-testid="guided-match-state">{latestGuidedInput.status}</dd>
+              </div>
+              <div>
+                <dt>Match progress</dt>
+                <dd data-testid="guided-match-progress">
+                  {Math.round(latestGuidedInput.progress * 100)}%
+                </dd>
+              </div>
             </dl>
 
             <div className="scene-badges" aria-label="Detected motifs">
@@ -168,19 +209,19 @@ export function App() {
               <button
                 disabled={strokes.length === 0}
                 onClick={() => {
-                  setGuidedSelections((currentSelections) => {
+                  setGuidedAttempts((currentAttempts) => {
                     if (strokes.length === 0) {
-                      return currentSelections;
+                      return currentAttempts;
                     }
 
-                    const nextSelections = { ...currentSelections };
+                    const nextAttempts = { ...currentAttempts };
                     const latestStroke = strokes.at(-1);
 
                     if (latestStroke) {
-                      delete nextSelections[latestStroke.id];
+                      delete nextAttempts[latestStroke.id];
                     }
 
-                    return nextSelections;
+                    return nextAttempts;
                   });
                   dispatch({ type: "undo" });
                 }}

--- a/src/features/guides/model/guideMatch.ts
+++ b/src/features/guides/model/guideMatch.ts
@@ -1,0 +1,30 @@
+import type {
+  GuideTemplate,
+  GuidedInputState,
+  Stroke,
+} from "../../../shared/types/domain";
+
+const GUIDE_MATCH_THRESHOLD = 0.6;
+
+export function calculateGuideProgress(stroke: Stroke, guide: GuideTemplate) {
+  if (guide.previewPath.length === 0) {
+    return 0;
+  }
+
+  const progress = stroke.points.length / guide.previewPath.length;
+
+  return Number(Math.min(1, progress).toFixed(2));
+}
+
+export function evaluateGuideMatch(
+  stroke: Stroke,
+  guide: GuideTemplate,
+): GuidedInputState {
+  const progress = calculateGuideProgress(stroke, guide);
+
+  return {
+    selectedGuideId: guide.id,
+    status: progress >= GUIDE_MATCH_THRESHOLD ? "matched" : "failed",
+    progress,
+  };
+}

--- a/src/shared/types/domain.ts
+++ b/src/shared/types/domain.ts
@@ -28,6 +28,14 @@ export type GuideTemplate = {
   previewPath: Point[];
 };
 
+export type GuidedInputStatus = "idle" | "tracing" | "matched" | "failed";
+
+export type GuidedInputState = {
+  selectedGuideId: string | null;
+  status: GuidedInputStatus;
+  progress: number;
+};
+
 export type SceneElement = {
   id: string;
   strokeIds: string[];

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -38,10 +38,30 @@ test("maps a guided drawing to the selected motif badge", async ({ page }) => {
   const canvas = page.getByLabel("BGM Canvas drawing surface");
   await canvas.hover({ position: { x: 120, y: 200 } });
   await page.mouse.down();
-  await page.mouse.move(280, 220, { steps: 6 });
+  await page.mouse.move(280, 220, { steps: 8 });
   await page.mouse.up();
 
+  await expect(page.getByTestId("guided-match-state")).toHaveText("matched");
   await expect(page.getByTestId("scene-badge").first()).toContainText("rain");
+});
+
+test("keeps a short guided stroke in failed state without a scene badge", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Rain guide" }).click();
+
+  const canvas = page.getByLabel("BGM Canvas drawing surface");
+  await canvas.hover({ position: { x: 120, y: 200 } });
+  await page.mouse.down();
+  await page.mouse.move(145, 206, { steps: 2 });
+  await page.mouse.up();
+
+  await expect(page.getByTestId("guided-match-state")).toHaveText("failed");
+  await expect(page.getByTestId("scene-count")).toHaveText("0");
+  await expect(page.getByTestId("audio-state")).toHaveText("idle");
+  await expect(page.getByText("No scene elements yet.")).toBeVisible();
 });
 
 test("stores one stroke after drawing on the canvas", async ({ page }) => {
@@ -57,7 +77,7 @@ test("stores one stroke after drawing on the canvas", async ({ page }) => {
   await expect(page.getByTestId("scene-count")).toHaveText("1");
   await expect(page.getByTestId("audio-layer-count")).toHaveText("1");
   await expect(page.getByTestId("audio-state")).toHaveText("playing");
-  await expect(page.getByTestId("scene-badge").first()).toContainText("campfire");
+  await expect(page.getByTestId("scene-badge").first()).toContainText("tree");
 });
 
 test("undo and reset control the current drawing session", async ({ page }) => {

--- a/tests/unit/app-smoke.test.tsx
+++ b/tests/unit/app-smoke.test.tsx
@@ -112,14 +112,26 @@ describe("App bootstrap", () => {
       buttons: 1,
     });
     fireEvent.pointerMove(canvas, {
+      clientX: 120,
+      clientY: 175,
+      pointerId: 1,
+      buttons: 1,
+    });
+    fireEvent.pointerMove(canvas, {
       clientX: 220,
       clientY: 190,
       pointerId: 1,
       buttons: 1,
     });
+    fireEvent.pointerMove(canvas, {
+      clientX: 320,
+      clientY: 210,
+      pointerId: 1,
+      buttons: 1,
+    });
     fireEvent.pointerUp(canvas, {
-      clientX: 220,
-      clientY: 190,
+      clientX: 320,
+      clientY: 210,
       pointerId: 1,
     });
 
@@ -127,8 +139,63 @@ describe("App bootstrap", () => {
       expect(screen.getByTestId("scene-count")).toHaveTextContent("1");
       expect(screen.getByTestId("audio-layer-count")).toHaveTextContent("1");
       expect(screen.getByTestId("audio-state")).toHaveTextContent("playing");
+      expect(screen.getByTestId("guided-match-state")).toHaveTextContent(
+        "matched",
+      );
       expect(screen.getByTestId("scene-badge")).toHaveTextContent("rain");
     });
+  });
+
+  it("does not create a scene element when the guided input is too short", async () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /rain guide/i }));
+
+    const canvas = screen.getByLabelText(
+      /bgm canvas drawing surface/i,
+    ) as HTMLCanvasElement;
+
+    canvas.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        width: 960,
+        height: 540,
+        right: 960,
+        bottom: 540,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    fireEvent.pointerDown(canvas, {
+      clientX: 20,
+      clientY: 160,
+      pointerId: 1,
+      buttons: 1,
+    });
+    fireEvent.pointerMove(canvas, {
+      clientX: 55,
+      clientY: 168,
+      pointerId: 1,
+      buttons: 1,
+    });
+    fireEvent.pointerUp(canvas, {
+      clientX: 55,
+      clientY: 168,
+      pointerId: 1,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stroke-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("scene-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("audio-layer-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("audio-state")).toHaveTextContent("idle");
+      expect(screen.getByTestId("guided-match-state")).toHaveTextContent(
+        "failed",
+      );
+    });
+    expect(screen.getByText(/no scene elements yet/i)).toBeInTheDocument();
   });
 
   it("undoes the most recent stroke and resets the session", async () => {

--- a/tests/unit/guides/guideMatch.test.ts
+++ b/tests/unit/guides/guideMatch.test.ts
@@ -1,0 +1,55 @@
+import { guideTemplates } from "../../../src/features/guides/model/guideTemplates";
+import { evaluateGuideMatch } from "../../../src/features/guides/model/guideMatch";
+import type { Stroke } from "../../../src/shared/types/domain";
+
+function createStroke(id: string, points: Stroke["points"]): Stroke {
+  return {
+    id,
+    points,
+    createdAt: 1,
+  };
+}
+
+describe("guide match", () => {
+  it("marks a sufficiently long guided stroke as matched", () => {
+    const rainGuide = guideTemplates.find((guide) => guide.motif === "rain");
+
+    expect(rainGuide).toBeDefined();
+
+    const result = evaluateGuideMatch(
+      createStroke("stroke-rain-match", [
+        { x: 20, y: 160 },
+        { x: 100, y: 170 },
+        { x: 180, y: 180 },
+        { x: 260, y: 195 },
+      ]),
+      rainGuide!,
+    );
+
+    expect(result).toMatchObject({
+      selectedGuideId: "guide-rain",
+      status: "matched",
+    });
+    expect(result.progress).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it("marks a short guided stroke as failed", () => {
+    const rainGuide = guideTemplates.find((guide) => guide.motif === "rain");
+
+    expect(rainGuide).toBeDefined();
+
+    const result = evaluateGuideMatch(
+      createStroke("stroke-rain-failed", [
+        { x: 20, y: 160 },
+        { x: 55, y: 168 },
+      ]),
+      rainGuide!,
+    );
+
+    expect(result).toMatchObject({
+      selectedGuideId: "guide-rain",
+      status: "failed",
+    });
+    expect(result.progress).toBeLessThan(0.6);
+  });
+});


### PR DESCRIPTION
## 요약
- guided input에 대해 progress와 `matched` / `failed` 상태를 계산합니다.
- match 성공인 guided stroke만 scene/audio로 반영합니다.
- app 상태 패널에 guide match 상태를 노출하고 관련 테스트를 확장합니다.

## 변경 사항
- `src/features/guides/model/guideMatch.ts` 추가
- `GuidedInputState` 타입 추가
- `App`에 guided attempt 상태 및 match 결과 연결
- unit/app/e2e smoke 테스트 확장

## 검증
- `npm run test`
- `npm run test:e2e`

Closes #14